### PR TITLE
use node.set for future chef 11 compatibility

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -20,7 +20,7 @@ remote_file l_path do
   action :create_if_missing
 end
 
-node[:crowd][:install][:current] = File.join(
+node.set[:crowd][:install][:current] = File.join(
   node[:crowd][:install][:dir],
   File.basename(l_path).sub(node[:crowd][:extensions][node[:crowd][:flavor]], '')
 )

--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -18,7 +18,7 @@ end
 
 ruby_block 'auto generate crowd mysql password' do
   block do
-    node[:crowd][:mysql][:password] = secure_password # NOTE: This method comes from mysql::server
+    node.set[:crowd][:mysql][:password] = secure_password # NOTE: This method comes from mysql::server
   end
   only_if do
     node[:crowd][:mysql][:auto_password] &&
@@ -60,7 +60,7 @@ execute 'unpack connectorj' do
   subscribes :run, resources(:remote_file => jcon_local), :immediately
 end
 
-node[:crowd][:mysql][:connectorj][:local_jar] = File.join(
+node.set[:crowd][:mysql][:connectorj][:local_jar] = File.join(
   node[:crowd][:scratch_dir],
   File.basename(jcon_local).sub('.tar.gz', ''),
   "#{File.basename(jcon_local).sub('.tar.gz', '')}-bin.jar"


### PR DESCRIPTION
small update for chef 11, should fix this type of warning:

```
2013-01-30T22:05:17-05:00] WARN: Setting attributes without specifying a precedence is deprecated and will be
removed in Chef 11.0. To set attributes at normal precedence, change code like:
`node["key"] = "value"` # Not this
to:
`node.set["key"] = "value"` # This
```
